### PR TITLE
feat: add modular tracker framework

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,10 +1,14 @@
-import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View, Navigation} from 'react-native';
-import RemindersPage from './screens/RemindersPage';
+import React, { useState } from "react";
+import HomeScreen from "./screens/HomeScreen";
+import trackers from "./trackers";
 
 export default function App() {
-  return (
-  <RemindersPage />
-  );
+  const [current, setCurrent] = useState("Home");
 
+  if (current === "Home") {
+    return <HomeScreen navigate={setCurrent} />;
+  }
+
+  const TrackerComponent = trackers[current];
+  return <TrackerComponent goBack={() => setCurrent("Home")} />;
 }

--- a/README.md
+++ b/README.md
@@ -1,10 +1,28 @@
-# 2DO
-Personal Project: 2DO - An online task manager. Users can create a todo list currently. Lists, repeating tasks, categories are still in development <br />
-Started on December 26, 2022. <br />
-Last updated on: February 7, 2023. <br />
+# 2DO LifeOS
 
-JAM STACK USED: <br />
-ReactJS using Typescript <br />
-Google Sheets API <br />
-Google Sheets as temporary database <br />
+A simple life management app built with Expo and React Native. The project now uses a modular tracker system aimed at helping people (especially those with ADHD) stay on top of important areas of life.
 
+## Available trackers
+- Reminders
+- Budget tracking
+- Expense tracking
+- Habit tracking
+- Career tracking
+- Goals tracking
+- Car tracking
+- Home tracking
+- Project tracking
+- School tracking
+- Workout schedule tracking
+- Daily affirmations
+- Weight tracking
+
+Each tracker lives in the `trackers` directory and can be expanded independently. To add a new tracker simply create a component and export it through `trackers/index.js`.
+
+## Running the app
+Install dependencies and start Expo:
+
+```bash
+npm install
+npm start
+```

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,0 +1,39 @@
+import React from "react";
+import { ScrollView, View, Button, StyleSheet } from "react-native";
+
+export default function HomeScreen({ navigate }) {
+  const trackers = [
+    { key: "Reminders", label: "Reminders" },
+    { key: "Budget", label: "Budget Tracker" },
+    { key: "Expense", label: "Expense Tracker" },
+    { key: "Habit", label: "Habit Tracker" },
+    { key: "Career", label: "Career Tracker" },
+    { key: "Goals", label: "Goals Tracker" },
+    { key: "Car", label: "Car Tracker" },
+    { key: "Home", label: "Home Tracker" },
+    { key: "Project", label: "Project Tracker" },
+    { key: "School", label: "School Tracker" },
+    { key: "Workout", label: "Workout Tracker" },
+    { key: "Affirmation", label: "Daily Affirmations" },
+    { key: "Weight", label: "Weight Tracker" }
+  ];
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      {trackers.map((t) => (
+        <View key={t.key} style={styles.button}>
+          <Button title={t.label} onPress={() => navigate(t.key)} />
+        </View>
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 20,
+  },
+  button: {
+    marginVertical: 5,
+  },
+});

--- a/trackers/AffirmationTracker.js
+++ b/trackers/AffirmationTracker.js
@@ -1,0 +1,6 @@
+import React from "react";
+import PlaceholderTracker from "./PlaceholderTracker";
+
+export default function ${t}Tracker(props) {
+  return <PlaceholderTracker title="${t} Tracker" {...props} />;
+}

--- a/trackers/BudgetTracker.js
+++ b/trackers/BudgetTracker.js
@@ -1,0 +1,6 @@
+import React from "react";
+import PlaceholderTracker from "./PlaceholderTracker";
+
+export default function ${t}Tracker(props) {
+  return <PlaceholderTracker title="${t} Tracker" {...props} />;
+}

--- a/trackers/CarTracker.js
+++ b/trackers/CarTracker.js
@@ -1,0 +1,6 @@
+import React from "react";
+import PlaceholderTracker from "./PlaceholderTracker";
+
+export default function ${t}Tracker(props) {
+  return <PlaceholderTracker title="${t} Tracker" {...props} />;
+}

--- a/trackers/CareerTracker.js
+++ b/trackers/CareerTracker.js
@@ -1,0 +1,6 @@
+import React from "react";
+import PlaceholderTracker from "./PlaceholderTracker";
+
+export default function ${t}Tracker(props) {
+  return <PlaceholderTracker title="${t} Tracker" {...props} />;
+}

--- a/trackers/ExpenseTracker.js
+++ b/trackers/ExpenseTracker.js
@@ -1,0 +1,6 @@
+import React from "react";
+import PlaceholderTracker from "./PlaceholderTracker";
+
+export default function ${t}Tracker(props) {
+  return <PlaceholderTracker title="${t} Tracker" {...props} />;
+}

--- a/trackers/GoalsTracker.js
+++ b/trackers/GoalsTracker.js
@@ -1,0 +1,6 @@
+import React from "react";
+import PlaceholderTracker from "./PlaceholderTracker";
+
+export default function ${t}Tracker(props) {
+  return <PlaceholderTracker title="${t} Tracker" {...props} />;
+}

--- a/trackers/HabitTracker.js
+++ b/trackers/HabitTracker.js
@@ -1,0 +1,6 @@
+import React from "react";
+import PlaceholderTracker from "./PlaceholderTracker";
+
+export default function ${t}Tracker(props) {
+  return <PlaceholderTracker title="${t} Tracker" {...props} />;
+}

--- a/trackers/HomeTracker.js
+++ b/trackers/HomeTracker.js
@@ -1,0 +1,6 @@
+import React from "react";
+import PlaceholderTracker from "./PlaceholderTracker";
+
+export default function ${t}Tracker(props) {
+  return <PlaceholderTracker title="${t} Tracker" {...props} />;
+}

--- a/trackers/PlaceholderTracker.js
+++ b/trackers/PlaceholderTracker.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { View, Text, Button, StyleSheet } from "react-native";
+
+export default function PlaceholderTracker({ title, goBack }) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>{title}</Text>
+      <Button title="Back" onPress={goBack} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 20,
+  },
+  text: {
+    fontSize: 18,
+    marginBottom: 10,
+  },
+});

--- a/trackers/ProjectTracker.js
+++ b/trackers/ProjectTracker.js
@@ -1,0 +1,6 @@
+import React from "react";
+import PlaceholderTracker from "./PlaceholderTracker";
+
+export default function ${t}Tracker(props) {
+  return <PlaceholderTracker title="${t} Tracker" {...props} />;
+}

--- a/trackers/RemindersTracker.js
+++ b/trackers/RemindersTracker.js
@@ -1,0 +1,18 @@
+import React from "react";
+import { View, Button, StyleSheet } from "react-native";
+import RemindersPage from "../screens/RemindersPage";
+
+export default function RemindersTracker({ goBack }) {
+  return (
+    <View style={styles.container}>
+      <Button title="Back" onPress={goBack} />
+      <RemindersPage />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/trackers/SchoolTracker.js
+++ b/trackers/SchoolTracker.js
@@ -1,0 +1,6 @@
+import React from "react";
+import PlaceholderTracker from "./PlaceholderTracker";
+
+export default function ${t}Tracker(props) {
+  return <PlaceholderTracker title="${t} Tracker" {...props} />;
+}

--- a/trackers/WeightTracker.js
+++ b/trackers/WeightTracker.js
@@ -1,0 +1,6 @@
+import React from "react";
+import PlaceholderTracker from "./PlaceholderTracker";
+
+export default function ${t}Tracker(props) {
+  return <PlaceholderTracker title="${t} Tracker" {...props} />;
+}

--- a/trackers/WorkoutTracker.js
+++ b/trackers/WorkoutTracker.js
@@ -1,0 +1,6 @@
+import React from "react";
+import PlaceholderTracker from "./PlaceholderTracker";
+
+export default function ${t}Tracker(props) {
+  return <PlaceholderTracker title="${t} Tracker" {...props} />;
+}

--- a/trackers/index.js
+++ b/trackers/index.js
@@ -1,0 +1,29 @@
+import RemindersTracker from "./RemindersTracker";
+import BudgetTracker from "./BudgetTracker";
+import ExpenseTracker from "./ExpenseTracker";
+import HabitTracker from "./HabitTracker";
+import CareerTracker from "./CareerTracker";
+import GoalsTracker from "./GoalsTracker";
+import CarTracker from "./CarTracker";
+import HomeTracker from "./HomeTracker";
+import ProjectTracker from "./ProjectTracker";
+import SchoolTracker from "./SchoolTracker";
+import WorkoutTracker from "./WorkoutTracker";
+import AffirmationTracker from "./AffirmationTracker";
+import WeightTracker from "./WeightTracker";
+
+export default {
+  Reminders: RemindersTracker,
+  Budget: BudgetTracker,
+  Expense: ExpenseTracker,
+  Habit: HabitTracker,
+  Career: CareerTracker,
+  Goals: GoalsTracker,
+  Car: CarTracker,
+  Home: HomeTracker,
+  Project: ProjectTracker,
+  School: SchoolTracker,
+  Workout: WorkoutTracker,
+  Affirmation: AffirmationTracker,
+  Weight: WeightTracker,
+};


### PR DESCRIPTION
## Summary
- add home screen and tracker modules for budgeting, habits and more
- provide placeholder components for future lifeOS features
- document tracker system and usage in README

## Testing
- `npm test` (fails: Missing script: "test")
- `npm start` (fails: Unable to reach Expo servers; Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68ad754d2718833194ffb85d7487ad25