### PR TITLE
Add Google Sheets auth backend and web client

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,25 @@ Install dependencies and start Expo:
 npm install
 npm start
 ```
+
+## Web frontend and Google Sheets backend
+This repository now includes a simple password-protected web client that reads its password from a Google Sheet.
+
+### Backend
+1. Copy `backend/.env.example` to `backend/.env` and fill in your Google service account credentials and sheet ID.
+2. Install dependencies and start the server:
+   ```bash
+   cd backend
+   npm install
+   npm start
+   ```
+   The server only accepts requests from iPhone user agents and checks the password stored in the sheet.
+
+### Frontend
+1. Install dependencies and run the development server:
+   ```bash
+   cd frontend
+   npm install
+   npm start
+   ```
+2. Visit `http://localhost:3000` from your iPhone and log in using the password stored in the sheet.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,5 @@
+PORT=4000
+SESSION_SECRET=super_secret_session_key
+GOOGLE_PROJECT_CREDENTIALS={"type":"service_account","project_id":"..."}
+SHEET_ID=YOUR_GOOGLE_SHEET_ID
+PASSWORD_CELL=A2

--- a/backend/googleSheets.js
+++ b/backend/googleSheets.js
@@ -1,0 +1,20 @@
+const { google } = require('googleapis');
+
+async function getSheetPassword() {
+  const creds = JSON.parse(process.env.GOOGLE_PROJECT_CREDENTIALS);
+  const auth = new google.auth.GoogleAuth({
+    credentials: creds,
+    scopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
+  });
+
+  const sheets = google.sheets({ version: 'v4', auth });
+  const range = process.env.PASSWORD_CELL || 'A2';
+  const res = await sheets.spreadsheets.values.get({
+    spreadsheetId: process.env.SHEET_ID,
+    range: `Sheet1!${range}`,
+  });
+
+  return res.data.values?.[0]?.[0] || '';
+}
+
+module.exports = { getSheetPassword };

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.0.0",
+    "express": "^4.18.2",
+    "express-session": "^1.17.3",
+    "googleapis": "^105.0.0"
+  }
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,47 @@
+require('dotenv').config();
+const express = require('express');
+const session = require('express-session');
+const cors = require('cors');
+const { getSheetPassword } = require('./googleSheets');
+
+const app = express();
+app.use(cors({ origin: 'http://localhost:3000', credentials: true }));
+app.use(express.json());
+app.use(
+  session({
+    secret: process.env.SESSION_SECRET,
+    resave: false,
+    saveUninitialized: false,
+    cookie: { secure: false, httpOnly: true },
+  })
+);
+
+// Restrict to iPhone user agents
+app.use((req, res, next) => {
+  const allowedDevice = /iPhone/i.test(req.headers['user-agent'] || '');
+  if (!allowedDevice) return res.status(403).json({ message: 'Device not allowed' });
+  next();
+});
+
+app.post('/login', async (req, res) => {
+  const { password } = req.body;
+  const sheetPassword = await getSheetPassword();
+
+  if (password === sheetPassword) {
+    req.session.authenticated = true;
+    res.json({ success: true });
+  } else {
+    res.status(401).json({ success: false, message: 'Invalid password' });
+  }
+});
+
+app.get('/protected-data', (req, res) => {
+  if (req.session.authenticated) {
+    res.json({ data: 'Secret info visible only after login' });
+  } else {
+    res.status(401).json({ message: 'Unauthorized' });
+  }
+});
+
+const port = process.env.PORT || 4000;
+app.listen(port, () => console.log(`Backend running on port ${port}`));

--- a/frontend/.babelrc
+++ b/frontend/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "axios": "^1.6.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.23.0",
+    "@babel/preset-env": "^7.23.0",
+    "@babel/preset-react": "^7.23.3",
+    "babel-loader": "^9.1.3",
+    "html-webpack-plugin": "^5.5.3",
+    "webpack": "^5.88.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
+  },
+  "scripts": {
+    "start": "webpack serve --mode development",
+    "build": "webpack --mode production"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,19 @@
+import React, { useState } from 'react';
+import Login from './Login';
+import Dashboard from './Dashboard';
+
+function App() {
+  const [loggedIn, setLoggedIn] = useState(false);
+
+  return (
+    <div>
+      {loggedIn ? (
+        <Dashboard />
+      ) : (
+        <Login onSuccess={() => setLoggedIn(true)} />
+      )}
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -1,0 +1,22 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+function Dashboard() {
+  const [data, setData] = useState('');
+
+  useEffect(() => {
+    axios
+      .get('http://localhost:4000/protected-data', { withCredentials: true })
+      .then((res) => setData(res.data.data))
+      .catch(() => setData('Failed to load'));
+  }, []);
+
+  return (
+    <div style={{ padding: '2em' }}>
+      <h1>Dashboard</h1>
+      <p>{data}</p>
+    </div>
+  );
+}
+
+export default Dashboard;

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+
+function Login({ onSuccess }) {
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+
+    try {
+      await axios.post('http://localhost:4000/login', { password }, { withCredentials: true });
+      onSuccess();
+    } catch {
+      setError('Incorrect password');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ maxWidth: 300, margin: '2em auto' }}>
+      <h2>Login</h2>
+      <input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        style={{ width: '100%', padding: '8px' }}
+      />
+      <button type="submit" style={{ marginTop: '1em', width: '100%' }}>Login</button>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+    </form>
+  );
+}
+
+export default Login;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,0 +1,27 @@
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: 'babel-loader',
+      },
+    ],
+  },
+  resolve: { extensions: ['.js', '.jsx'] },
+  devServer: {
+    port: 3000,
+    historyApiFallback: true,
+  },
+  plugins: [
+    new HtmlWebpackPlugin({ template: 'public/index.html' })
+  ],
+};


### PR DESCRIPTION
## Summary
- add Express backend that reads a password from Google Sheets and restricts access to iPhone user agents
- include sample React web client with login and dashboard
- document setup steps in README

## Testing
- `npm test` *(backend: missing script)*
- `npm test` *(frontend: missing script)*
- `npm test` *(root: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68ad78923b288331b214832443ed9288